### PR TITLE
Add sliding tile puzzle example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository collects a few data structure and algorithm examples written in 
 - **Searching/** – search algorithms such as binary search.
 - **Sorting/** – sorting algorithms like quick sort and merge sort.
 - **Problems/** – assorted example problems.
+- **SlidingTilePuzzle/** – small browser-based puzzle implemented with HTML, CSS and JavaScript.
 - **node_modules/** – npm dependencies that come bundled with the repository.
 - `util.js` – small utility functions used by examples.
 

--- a/SlidingTilePuzzle/index.html
+++ b/SlidingTilePuzzle/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sliding Tile Puzzle</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Sliding Tile Puzzle</h1>
+    <div id="board" class="board"></div>
+    <p id="message" class="message"></p>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/SlidingTilePuzzle/script.js
+++ b/SlidingTilePuzzle/script.js
@@ -1,0 +1,78 @@
+const boardEl = document.getElementById('board');
+const messageEl = document.getElementById('message');
+const size = 4; // 4x4 board
+let board = [];
+
+function initBoard() {
+  board = Array.from({ length: size * size }, (_, i) => (i + 1) % (size * size));
+  shuffleBoard();
+  render();
+}
+
+function shuffleBoard() {
+  // perform random moves from solved state to ensure solvable puzzle
+  for (let i = 0; i < 1000; i++) {
+    const empty = board.indexOf(0);
+    const neighbors = getNeighborIndices(empty);
+    const target = neighbors[Math.floor(Math.random() * neighbors.length)];
+    [board[empty], board[target]] = [board[target], board[empty]];
+  }
+}
+
+function getNeighborIndices(index) {
+  const neighbors = [];
+  const row = Math.floor(index / size);
+  const col = index % size;
+  if (row > 0) neighbors.push(index - size);
+  if (row < size - 1) neighbors.push(index + size);
+  if (col > 0) neighbors.push(index - 1);
+  if (col < size - 1) neighbors.push(index + 1);
+  return neighbors;
+}
+
+function render() {
+  boardEl.innerHTML = '';
+  board.forEach((value, idx) => {
+    const tile = document.createElement('div');
+    tile.className = 'tile';
+    if (value === 0) {
+      tile.classList.add('empty');
+    } else {
+      tile.textContent = value;
+      tile.addEventListener('click', () => handleTileClick(idx));
+    }
+    boardEl.appendChild(tile);
+  });
+}
+
+function handleTileClick(index) {
+  const empty = board.indexOf(0);
+  if (getNeighborIndices(empty).includes(index)) {
+    [board[empty], board[index]] = [board[index], board[empty]];
+    playBeep();
+    render();
+    checkSolved();
+  }
+}
+
+function checkSolved() {
+  for (let i = 0; i < board.length - 1; i++) {
+    if (board[i] !== i + 1) return;
+  }
+  messageEl.textContent = 'Puzzle Solved!';
+}
+
+function playBeep() {
+  const ctx = new (window.AudioContext || window.webkitAudioContext)();
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.frequency.value = 400;
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start();
+  gain.gain.setValueAtTime(1, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.1);
+  osc.stop(ctx.currentTime + 0.1);
+}
+
+initBoard();

--- a/SlidingTilePuzzle/style.css
+++ b/SlidingTilePuzzle/style.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    text-align: center;
+    padding: 20px;
+}
+
+.board {
+    display: grid;
+    grid-template-columns: repeat(4, 80px);
+    grid-template-rows: repeat(4, 80px);
+    gap: 5px;
+    margin: 20px auto;
+    width: max-content;
+}
+
+.tile {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #79a6d2;
+    color: white;
+    font-size: 24px;
+    font-weight: bold;
+    cursor: pointer;
+    border-radius: 4px;
+    user-select: none;
+}
+
+.empty {
+    background-color: #f0f0f0;
+    cursor: default;
+}
+
+.message {
+    font-size: 20px;
+    color: green;
+}


### PR DESCRIPTION
## Summary
- add a `SlidingTilePuzzle` folder with `index.html`, `style.css`, and `script.js`
- implement a simple sliding tile puzzle with sound effects using the Web Audio API
- mention new example in the README

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685f8d65d9f48325ac9c733724a3e0d8